### PR TITLE
Add simple Node.js PDF generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Catalog Web App
+
+This project provides a simple web application for generating DIN A4 PDFs from user input. It uses Node.js, Express and Puppeteer to render HTML templates and return a PDF to the browser.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+2. Start the development server:
+
+```bash
+npm start
+```
+
+3. Open `http://localhost:3000` in your browser and fill in the form to generate a PDF.
+
+## Notes
+
+- Puppeteer runs a headless version of Chromium. The server is configured to run with the `--no-sandbox` flag for environments like containers.
+- Generated PDFs will be sent directly to the browser as a download.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const app = express();
+
+app.use(express.urlencoded({ extended: true }));
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+
+app.get('/', (req, res) => {
+  res.render('form');
+});
+
+app.post('/generate', async (req, res, next) => {
+  const { title, content, color } = req.body;
+  const html = `
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <style>
+          @page { size: A4; margin: 20mm; }
+          body { font-family: sans-serif; color: #333; }
+          h1 { color: ${color || '#333'}; }
+        </style>
+      </head>
+      <body>
+        <h1>${title}</h1>
+        <p>${content}</p>
+      </body>
+    </html>
+  `;
+
+  try {
+    const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle0' });
+    const buffer = await page.pdf({ format: 'A4', printBackground: true });
+    await browser.close();
+    res.contentType('application/pdf');
+    res.send(buffer);
+  } catch (err) {
+    next(err);
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "catalog-webapp",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ejs": "^3.1.10",
+    "puppeteer": "^22.5.0"
+  }
+}

--- a/views/form.ejs
+++ b/views/form.ejs
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>PDF Generator</title>
+</head>
+<body>
+  <h1>Create PDF</h1>
+  <form method="POST" action="/generate">
+    <div>
+      <label>Title:</label>
+      <input type="text" name="title" required />
+    </div>
+    <div>
+      <label>Content:</label>
+      <textarea name="content" required></textarea>
+    </div>
+    <div>
+      <label>Brand Color:</label>
+      <input type="color" name="color" />
+    </div>
+    <button type="submit">Generate PDF</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize Node.js project for catalog web app
- add express-based PDF generator using puppeteer
- document setup steps in README
- create basic form template

## Testing
- `npm install` *(fails: ENOTFOUND)*